### PR TITLE
Fix ticker text spans two lines

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,8 +21,8 @@ function App() {
   const fetchData = useCallback(async (isInitialLoad: boolean) => {
     try {
       const [slidesResponse, tickerResponse] = await Promise.all([
-        fetch('https://cms.tv-krant.nl/wp-json/zw/v1/teksttv-slides'),
-        fetch('https://cms.tv-krant.nl/wp-json/zw/v1/teksttv-ticker'),
+        fetch('https://preview.zuidwestupdate.nl/wp-json/zw/v1/teksttv-slides'),
+        fetch('https://preview.zuidwestupdate.nl/wp-json/zw/v1/teksttv-ticker'),
       ])
       const newSlides = await slidesResponse.json()
       const newTickerItems = await tickerResponse.json()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,8 +21,8 @@ function App() {
   const fetchData = useCallback(async (isInitialLoad: boolean) => {
     try {
       const [slidesResponse, tickerResponse] = await Promise.all([
-        fetch('https://preview.zuidwestupdate.nl/wp-json/zw/v1/teksttv-slides'),
-        fetch('https://preview.zuidwestupdate.nl/wp-json/zw/v1/teksttv-ticker'),
+        fetch('https://cms.tv-krant.nl/wp-json/zw/v1/teksttv-slides'),
+        fetch('https://cms.tv-krant.nl/wp-json/zw/v1/teksttv-ticker'),
       ])
       const newSlides = await slidesResponse.json()
       const newTickerItems = await tickerResponse.json()

--- a/src/components/Ticker.tsx
+++ b/src/components/Ticker.tsx
@@ -9,7 +9,9 @@ export const Ticker = ({
 
   return (
     <div className="absolute right-0 bottom-[91px] left-0 z-30 flex items-center bg-black font-bold font-tahoma text-[#F7BF19] text-[51px] tracking-wide">
-      <span className="grow pl-[121px]">{items[currentIndex].message}</span>
+      <span className="min-w-0 grow truncate pl-[121px]">
+        {items[currentIndex].message}
+      </span>
       <div className="relative w-[10px] self-stretch">
         <svg
           className="h-full w-full fill-white"


### PR DESCRIPTION
Fixes #29

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/oszuidwest/teksttv/issues/29?shareId=91e550ed-fc45-46b7-bc9d-a7996f21739c).