### PR TITLE
Update biome schema to match CLI version

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## Summary
- Update biome.json schema reference from 2.3.14 to 2.4.8 to match the installed CLI version
- Removes the `deserialize` warning on every check run