### PR TITLE
Add caption and attribution support for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ All slides are 1920x1080 pixels. Each slide has a `duration` (in milliseconds) t
 - **Type**: `text`
 - Displays a title and body text with an optional sidebar image.
 - Supports HTML in title and body fields.
-- The `image` field accepts a URL string (legacy) or an object with `url`, optional `caption`, and optional `attribution`.
+- The `image` field is an object with `url`, optional `caption`, and optional `attribution`.
 
 ### Image Slide
 - **Type**: `image`

--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ All slides are 1920x1080 pixels. Each slide has a `duration` (in milliseconds) t
 - **Type**: `text`
 - Displays a title and body text with an optional sidebar image.
 - Supports HTML in title and body fields.
+- The `image` field accepts a URL string (legacy) or an object with `url`, optional `caption`, and optional `attribution`.
 
 ### Image Slide
 - **Type**: `image`
 - Displays a full-screen image.
+- Supports optional `caption` and `attribution` fields.
 
 ### Weather Slide
 - **Type**: `weather`

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ The Release workflow only creates a new release if the version in `package.json`
 
 All slides are 1920x1080 pixels. Each slide has a `duration` (in milliseconds) that determines how long it is displayed.
 
+> **Note:** The `caption` and `attribution` fields on text and image slides are accepted by the schema but currently rendered only by **BredaNu** (onboarding in progress). The ZuidWest and Rucphen templates ignore these fields, so they will not appear on screen there.
+
 ### Text Slide
 - **Type**: `text`
 - Displays a title and body text with an optional sidebar image.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.8",
+        "@types/bun": "^1.3.13",
         "@types/react": "^19.2.13",
         "@types/react-dom": "^19.2.3",
         "typescript": "^5.9.3",
@@ -316,6 +317,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -327,6 +330,8 @@
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -369,6 +374,8 @@
     "boxen": ["boxen@8.0.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^8.0.0", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "string-width": "^7.2.0", "type-fest": "^4.21.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0" } }, "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
 
@@ -813,6 +820,8 @@
     "ultrahtml": ["ultrahtml@1.6.0", "", {}, "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw=="],
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "check": "tsc --noEmit && biome ci .",
+    "test": "bun test",
+    "check": "tsc --noEmit && bun test && biome ci .",
     "fix": "biome check --write .",
     "fix:unsafe": "biome check --write --unsafe ."
   },
@@ -23,6 +24,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
+    "@types/bun": "^1.3.13",
     "@types/react": "^19.2.13",
     "@types/react-dom": "^19.2.3",
     "typescript": "^5.9.3"

--- a/src/components/rucphen/TextSlide.tsx
+++ b/src/components/rucphen/TextSlide.tsx
@@ -1,4 +1,4 @@
-import type { TextSlideData } from '../../types'
+import { resolveImageUrl, type TextSlideData } from '../../types'
 
 export const TextSlide = ({
   content,
@@ -9,7 +9,11 @@ export const TextSlide = ({
 }) => (
   <div className="relative h-full w-full bg-[#BBBBBB] font-tahoma">
     <div className="sidebar absolute inset-0 inset-y-0 left-0 z-10 w-[604px] bg-[#F7BF19]">
-      <img src={content.image} alt="" className="inset-0 h-full object-cover" />
+      <img
+        src={resolveImageUrl(content.image)}
+        alt=""
+        className="inset-0 h-full object-cover"
+      />
     </div>
     <svg
       className="absolute inset-0 z-5 h-full w-full"

--- a/src/components/rucphen/TextSlide.tsx
+++ b/src/components/rucphen/TextSlide.tsx
@@ -9,11 +9,13 @@ export const TextSlide = ({
 }) => (
   <div className="relative h-full w-full bg-[#BBBBBB] font-tahoma">
     <div className="sidebar absolute inset-0 inset-y-0 left-0 z-10 w-[604px] bg-[#F7BF19]">
-      <img
-        src={content.image?.url}
-        alt=""
-        className="inset-0 h-full object-cover"
-      />
+      {content.image?.url && (
+        <img
+          src={content.image.url}
+          alt=""
+          className="inset-0 h-full object-cover"
+        />
+      )}
     </div>
     <svg
       className="absolute inset-0 z-5 h-full w-full"

--- a/src/components/rucphen/TextSlide.tsx
+++ b/src/components/rucphen/TextSlide.tsx
@@ -1,4 +1,4 @@
-import { resolveImageUrl, type TextSlideData } from '../../types'
+import type { TextSlideData } from '../../types'
 
 export const TextSlide = ({
   content,
@@ -10,7 +10,7 @@ export const TextSlide = ({
   <div className="relative h-full w-full bg-[#BBBBBB] font-tahoma">
     <div className="sidebar absolute inset-0 inset-y-0 left-0 z-10 w-[604px] bg-[#F7BF19]">
       <img
-        src={resolveImageUrl(content.image)}
+        src={content.image?.url}
         alt=""
         className="inset-0 h-full object-cover"
       />

--- a/src/components/zuidwest/TextSlide.tsx
+++ b/src/components/zuidwest/TextSlide.tsx
@@ -1,4 +1,4 @@
-import { resolveImageUrl, type TextSlideData } from '../../types'
+import type { TextSlideData } from '../../types'
 
 const themes = {
   green: { border: '#82ba26' },
@@ -15,7 +15,7 @@ export function TextSlide({
   children?: React.ReactNode
 }) {
   const c = themes[theme]
-  const imageUrl = resolveImageUrl(content.image)
+  const imageUrl = content.image?.url
   const hasImage = !!imageUrl
 
   return (

--- a/src/components/zuidwest/TextSlide.tsx
+++ b/src/components/zuidwest/TextSlide.tsx
@@ -1,4 +1,4 @@
-import type { TextSlideData } from '../../types'
+import { resolveImageUrl, type TextSlideData } from '../../types'
 
 const themes = {
   green: { border: '#82ba26' },
@@ -15,7 +15,8 @@ export function TextSlide({
   children?: React.ReactNode
 }) {
   const c = themes[theme]
-  const hasImage = content.image && content.image.length > 0
+  const imageUrl = resolveImageUrl(content.image)
+  const hasImage = !!imageUrl
 
   return (
     <>
@@ -59,7 +60,7 @@ export function TextSlide({
       {/* Photo (outside card so it extends behind overlay stripes) */}
       {hasImage && (
         <img
-          src={content.image}
+          src={imageUrl}
           alt=""
           className="absolute top-[160px] right-0 z-10 h-[440px] w-[640px] object-cover"
           style={{ borderBottomLeftRadius: '64px' }}

--- a/src/hooks/useCarousel.ts
+++ b/src/hooks/useCarousel.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import type { SlideData, TickerItem } from '../types'
-import { SlideDataSchema, TickerItemSchema } from '../types'
+import { resolveImageUrl, SlideDataSchema, TickerItemSchema } from '../types'
 
 export function useCarousel({
   apiBase,
@@ -31,6 +31,14 @@ export function useCarousel({
           parsed.error.issues,
         )
         return []
+      }
+      if (
+        parsed.data.type === 'text' &&
+        typeof parsed.data.image === 'string'
+      ) {
+        console.warn(
+          `Slide ${index} from ${source}: "image" as a plain string is deprecated. Use { url, caption?, attribution? } instead.`,
+        )
       }
       return [parsed.data]
     })
@@ -111,7 +119,7 @@ export function useCarousel({
               .flatMap((slide: SlideData) => {
                 switch (slide.type) {
                   case 'text':
-                    return slide.image || undefined
+                    return resolveImageUrl(slide.image)
                   case 'image':
                   case 'commercial':
                   case 'commercial_transition':

--- a/src/hooks/useCarousel.ts
+++ b/src/hooks/useCarousel.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import type { SlideData, TickerItem } from '../types'
-import { resolveImageUrl, SlideDataSchema, TickerItemSchema } from '../types'
+import { SlideDataSchema, TickerItemSchema } from '../types'
 
 export function useCarousel({
   apiBase,
@@ -31,14 +31,6 @@ export function useCarousel({
           parsed.error.issues,
         )
         return []
-      }
-      if (
-        parsed.data.type === 'text' &&
-        typeof parsed.data.image === 'string'
-      ) {
-        console.warn(
-          `Slide ${index} from ${source}: "image" as a plain string is deprecated. Use { url, caption?, attribution? } instead.`,
-        )
       }
       return [parsed.data]
     })
@@ -119,7 +111,7 @@ export function useCarousel({
               .flatMap((slide: SlideData) => {
                 switch (slide.type) {
                   case 'text':
-                    return resolveImageUrl(slide.image)
+                    return slide.image?.url
                   case 'image':
                   case 'commercial':
                   case 'commercial_transition':
@@ -184,7 +176,7 @@ export function useCarousel({
                 .flatMap((slide) => {
                   switch (slide.type) {
                     case 'text':
-                      return slide.image || undefined
+                      return slide.image?.url
                     case 'image':
                     case 'commercial':
                     case 'commercial_transition':

--- a/src/pages/rucphen/dev/text.astro
+++ b/src/pages/rucphen/dev/text.astro
@@ -13,7 +13,9 @@ import { Ticker } from '../../../components/rucphen/Ticker'
         duration: 20000,
         title: 'LIVE PROGRAMMERING WOENSDAG',
         body: '<p>Informatie met muziek. Dat is het fundament waar Radio Rucphen succesvol mee is.</p><p>We beginnen \'s morgens met de actualiteiten die een lokaal gekleurd tintje hebben.<br />\'s Avonds wordt de week doormidden gebroken met lokale info en vervolgens gaan de Goudzoekers op pad. Met muziek en spelletjes voor de meespelende luisteraar.</p><p>(1/1)</p>',
-        image: 'https://cms.tv-krant.nl/wp-content/uploads/2024/10/Informatie-2.png',
+        image: {
+          url: 'https://cms.tv-krant.nl/wp-content/uploads/2024/10/Informatie-2.png',
+        },
       }}
     >
       <Ticker

--- a/src/pages/zuidwest-1/dev/text-image.astro
+++ b/src/pages/zuidwest-1/dev/text-image.astro
@@ -4,6 +4,8 @@ import { Frame } from '../../../components/zuidwest/Frame'
 import { TextSlide } from '../../../components/zuidwest/TextSlide'
 import { Ticker } from '../../../components/zuidwest/Ticker'
 import { DevOverlay } from '../../../components/zuidwest/DevOverlay'
+
+const samplePhotoUrl = new URL('/dev/sample-photo.png', Astro.url).toString()
 ---
 
 <Layout title="Dev - ZuidWest Text (with photo)">
@@ -17,7 +19,9 @@ import { DevOverlay } from '../../../components/zuidwest/DevOverlay'
           duration: 10000,
           title: 'In dit boskantoor kunnen boswachters mobiel werken',
           body: '<p>ZUNDERT - Anno 2024 zit de boswachter niet de hele dag in het bos, maar ook op kantoor. Daar is iets voor bedacht, namelijk een mobiel boskantoor. Als aanhangwagen, gekoppeld aan de pick-uptruck, kunnen boswachters van Staatsbosbeheer ook in het bos met de laptop aan de slag. Met de mobiele werkplek kunnen boswachters zowel administratieve als fysieke werkzaamheden in het bos verrichten.</p>',
-          image: '/dev/sample-photo.png',
+          image: {
+            url: samplePhotoUrl,
+          },
         }}
       >
         <Ticker

--- a/src/pages/zuidwest-1/dev/text.astro
+++ b/src/pages/zuidwest-1/dev/text.astro
@@ -17,7 +17,6 @@ import { DevOverlay } from '../../../components/zuidwest/DevOverlay'
           duration: 10000,
           title: 'Nieuwe mijlpaal werkzaamheden Fort Sabina: gevelrestauratie afgerond',
           body: '<p>HEIJNINGEN - Een feestelijk moment bij Fort Sabina, want de gevel van het eeuwenoude gebouw is helemaal opgeknapt. Begin dit jaar startten de restauratiewerkzaamheden. In oktober zijn de werkzaamheden afgerond. Een mijlpaal om bij stil te staan, en bij vooruit te blikken. Het stond al zeker vijf jaar op de planning om de gevel van het imposante fort aan te pakken.</p><p>Hiervoor waren maarliefst veertig duizend stenen nodig. Door corona vertraagde de renovatie, maar het is nu helemaal af. Het volgende project is de renovatie van de Botenloods.</p>',
-          image: '',
         }}
       >
         <Ticker

--- a/src/types.examples.ts
+++ b/src/types.examples.ts
@@ -17,7 +17,7 @@ export const textSlide = {
   duration: 15000,
   title: 'News of the Day',
   body: 'This is a news article with <strong>HTML</strong> support.',
-  image: 'https://example.com/sidebar.jpg',
+  image: { url: 'https://example.com/sidebar.jpg' },
 } satisfies TextSlideData
 
 export const textSlideWithImageData = {

--- a/src/types.examples.ts
+++ b/src/types.examples.ts
@@ -20,10 +20,30 @@ export const textSlide = {
   image: 'https://example.com/sidebar.jpg',
 } satisfies TextSlideData
 
+export const textSlideWithImageData = {
+  type: 'text',
+  duration: 15000,
+  title: 'News with Attribution',
+  body: 'This article has an image with caption and attribution.',
+  image: {
+    url: 'https://example.com/sidebar.jpg',
+    caption: 'A beautiful sunset',
+    attribution: 'Photo by Jane Doe',
+  },
+} satisfies TextSlideData
+
 export const imageSlide = {
   type: 'image',
   duration: 10000,
   url: 'https://example.com/image.jpg',
+} satisfies ImageSlideData
+
+export const imageSlideWithMeta = {
+  type: 'image',
+  duration: 10000,
+  url: 'https://example.com/image.jpg',
+  caption: 'Town hall during sunset',
+  attribution: 'Photo by John Smith',
 } satisfies ImageSlideData
 
 export const weatherSlide = {

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'bun:test'
+import { ImageSlideDataSchema, TextSlideDataSchema } from './types'
+
+const baseTextSlide = {
+  type: 'text',
+  duration: 1000,
+  title: 'Title',
+  body: 'Body',
+} as const
+
+const baseImageSlide = {
+  type: 'image',
+  duration: 1000,
+} as const
+
+describe('TextSlideDataSchema image normalization', () => {
+  test('accepts a missing image', () => {
+    const parsed = TextSlideDataSchema.parse(baseTextSlide)
+
+    expect(parsed).not.toHaveProperty('image')
+  })
+
+  test('normalizes null image to undefined', () => {
+    const parsed = TextSlideDataSchema.parse({
+      ...baseTextSlide,
+      image: null,
+    })
+
+    expect(parsed.image).toBeUndefined()
+  })
+
+  test('accepts an image object with a URL', () => {
+    const parsed = TextSlideDataSchema.parse({
+      ...baseTextSlide,
+      image: { url: 'https://example.com/sidebar.jpg' },
+    })
+
+    expect(parsed.image).toEqual({
+      url: 'https://example.com/sidebar.jpg',
+    })
+  })
+
+  test('keeps caption and attribution on valid image data', () => {
+    const parsed = TextSlideDataSchema.parse({
+      ...baseTextSlide,
+      image: {
+        url: 'https://example.com/sidebar.jpg',
+        caption: 'Caption',
+        attribution: 'Credit',
+      },
+    })
+
+    expect(parsed.image).toEqual({
+      url: 'https://example.com/sidebar.jpg',
+      caption: 'Caption',
+      attribution: 'Credit',
+    })
+  })
+
+  test('rejects an image object with an invalid URL', () => {
+    expect(() =>
+      TextSlideDataSchema.parse({
+        ...baseTextSlide,
+        image: { url: 'not-a-url' },
+      }),
+    ).toThrow()
+  })
+
+  test('rejects image metadata without a URL', () => {
+    expect(() =>
+      TextSlideDataSchema.parse({
+        ...baseTextSlide,
+        image: { caption: 'Caption without image' },
+      }),
+    ).toThrow()
+  })
+})
+
+describe('ImageSlideDataSchema', () => {
+  test('accepts a full-screen image slide with a URL', () => {
+    const parsed = ImageSlideDataSchema.parse({
+      ...baseImageSlide,
+      url: 'https://example.com/image.jpg',
+    })
+
+    expect(parsed).toEqual({
+      ...baseImageSlide,
+      url: 'https://example.com/image.jpg',
+    })
+  })
+
+  test('keeps caption and attribution on full-screen image slides', () => {
+    const parsed = ImageSlideDataSchema.parse({
+      ...baseImageSlide,
+      url: 'https://example.com/image.jpg',
+      caption: 'Caption',
+      attribution: 'Credit',
+    })
+
+    expect(parsed).toEqual({
+      ...baseImageSlide,
+      url: 'https://example.com/image.jpg',
+      caption: 'Caption',
+      attribution: 'Credit',
+    })
+  })
+
+  test('rejects a full-screen image slide without a URL', () => {
+    expect(() => ImageSlideDataSchema.parse(baseImageSlide)).toThrow()
+  })
+
+  test('rejects a full-screen image slide with an invalid URL', () => {
+    expect(() =>
+      ImageSlideDataSchema.parse({
+        ...baseImageSlide,
+        url: 'not-a-url',
+      }),
+    ).toThrow()
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export const TextSlideDataSchema = BaseSlideSchema.extend({
   type: z.literal('text'),
   title: z.string().describe('Slide title (HTML supported)'),
   body: z.string().describe('Main content (HTML supported)'),
-  image: ImageDataSchema.describe('Sidebar image'),
+  image: ImageDataSchema.describe('Sidebar image').optional(),
 })
 
 export const WeatherDaySchema = z.object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,16 +4,28 @@ const BaseSlideSchema = z.object({
   duration: z.number().positive().describe('Display duration in milliseconds'),
 })
 
+export const ImageDataSchema = z.object({
+  url: z.string().url(),
+  caption: z.string().optional(),
+  attribution: z.string().optional(),
+})
+
+const ImageFieldSchema = z.union([z.string().url(), ImageDataSchema])
+
 export const ImageSlideDataSchema = BaseSlideSchema.extend({
   type: z.literal('image'),
   url: z.string().url(),
+  caption: z.string().optional(),
+  attribution: z.string().optional(),
 })
 
 export const TextSlideDataSchema = BaseSlideSchema.extend({
   type: z.literal('text'),
   title: z.string().describe('Slide title (HTML supported)'),
   body: z.string().describe('Main content (HTML supported)'),
-  image: z.string().describe('Optional sidebar image URL'),
+  image: ImageFieldSchema.describe(
+    'Sidebar image: URL string (legacy) or image object',
+  ),
 })
 
 export const WeatherDaySchema = z.object({
@@ -93,6 +105,7 @@ export const ChannelPayloadSchema = z.object({
 })
 
 // Type inference
+export type ImageData = z.infer<typeof ImageDataSchema>
 export type ImageSlideData = z.infer<typeof ImageSlideDataSchema>
 export type TextSlideData = z.infer<typeof TextSlideDataSchema>
 export type WeatherDay = z.infer<typeof WeatherDaySchema>
@@ -109,3 +122,11 @@ export type FullScreenSlideData =
   | ImageSlideData
   | CommercialSlideData
   | CommercialTransitionSlideData
+
+/** Extracts the URL from an image field that can be a plain string or an ImageData object */
+export function resolveImageUrl(
+  image: string | ImageData | undefined,
+): string | undefined {
+  if (!image) return undefined
+  return typeof image === 'string' ? image : image.url
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,6 @@ export const ImageDataSchema = z.object({
   attribution: z.string().optional(),
 })
 
-const ImageFieldSchema = z.union([z.string().url(), ImageDataSchema])
-
 export const ImageSlideDataSchema = BaseSlideSchema.extend({
   type: z.literal('image'),
   url: z.string().url(),
@@ -23,9 +21,7 @@ export const TextSlideDataSchema = BaseSlideSchema.extend({
   type: z.literal('text'),
   title: z.string().describe('Slide title (HTML supported)'),
   body: z.string().describe('Main content (HTML supported)'),
-  image: ImageFieldSchema.describe(
-    'Sidebar image: URL string (legacy) or image object',
-  ),
+  image: ImageDataSchema.describe('Sidebar image'),
 })
 
 export const WeatherDaySchema = z.object({
@@ -122,11 +118,3 @@ export type FullScreenSlideData =
   | ImageSlideData
   | CommercialSlideData
   | CommercialTransitionSlideData
-
-/** Extracts the URL from an image field that can be a plain string or an ImageData object */
-export function resolveImageUrl(
-  image: string | ImageData | undefined,
-): string | undefined {
-  if (!image) return undefined
-  return typeof image === 'string' ? image : image.url
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,23 +5,36 @@ const BaseSlideSchema = z.object({
 })
 
 export const ImageDataSchema = z.object({
-  url: z.string().url(),
-  caption: z.string().optional(),
-  attribution: z.string().optional(),
+  url: z.string().url().describe('Image URL'),
+  caption: z.string().optional().describe('Image caption'),
+  attribution: z.string().optional().describe('Image attribution or credit'),
 })
 
-export const ImageSlideDataSchema = BaseSlideSchema.extend({
+function normalizeOptionalImageData(value: unknown) {
+  // Upstream CMS emits null when a text slide has no sidebar image.
+  if (value === null) {
+    return undefined
+  }
+
+  return value
+}
+
+const OptionalImageDataSchema = z.preprocess(
+  normalizeOptionalImageData,
+  ImageDataSchema.optional(),
+)
+
+export const ImageSlideDataSchema = BaseSlideSchema.merge(
+  ImageDataSchema,
+).extend({
   type: z.literal('image'),
-  url: z.string().url(),
-  caption: z.string().optional(),
-  attribution: z.string().optional(),
 })
 
 export const TextSlideDataSchema = BaseSlideSchema.extend({
   type: z.literal('text'),
   title: z.string().describe('Slide title (HTML supported)'),
   body: z.string().describe('Main content (HTML supported)'),
-  image: ImageDataSchema.describe('Sidebar image').optional(),
+  image: OptionalImageDataSchema.describe('Optional sidebar image'),
 })
 
 export const WeatherDaySchema = z.object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ const BaseSlideSchema = z.object({
 })
 
 export const ImageDataSchema = z.object({
-  url: z.string().url().describe('Image URL'),
+  url: z.url().describe('Image URL'),
   caption: z.string().optional().describe('Image caption'),
   attribution: z.string().optional().describe('Image attribution or credit'),
 })
@@ -24,10 +24,9 @@ const OptionalImageDataSchema = z.preprocess(
   ImageDataSchema.optional(),
 )
 
-export const ImageSlideDataSchema = BaseSlideSchema.merge(
-  ImageDataSchema,
-).extend({
+export const ImageSlideDataSchema = BaseSlideSchema.extend({
   type: z.literal('image'),
+  ...ImageDataSchema.shape,
 })
 
 export const TextSlideDataSchema = BaseSlideSchema.extend({
@@ -82,12 +81,12 @@ export const WeatherSlideDataSchema = BaseSlideSchema.extend({
 
 export const CommercialSlideDataSchema = BaseSlideSchema.extend({
   type: z.literal('commercial'),
-  url: z.string().url(),
+  url: z.url(),
 })
 
 export const CommercialTransitionSlideDataSchema = BaseSlideSchema.extend({
   type: z.literal('commercial_transition'),
-  url: z.string().url(),
+  url: z.url(),
 })
 
 export const SlideDataSchema = z.discriminatedUnion('type', [


### PR DESCRIPTION
- Adds `ImageDataSchema` with `url`, optional `caption`, and optional `attribution`
- `ImageSlideDataSchema` gets optional `caption` and `attribution` at root level
- `TextSlideDataSchema` `image` field now accepts both a plain URL string (legacy) and the new object format
- Deprecation warning logged once per fetch for text slides still using the legacy string format
- Updated README with new field documentation