### PR TITLE
chore: collapse w-N h-N to Tailwind size-N shorthand

### DIFF
--- a/src/components/rucphen/WeatherSlide.tsx
+++ b/src/components/rucphen/WeatherSlide.tsx
@@ -30,7 +30,7 @@ function WindArrow({ direction }: { direction: string }) {
 
   return (
     <svg
-      className="h-[48px] w-[48px] shrink-0"
+      className="size-[48px] shrink-0"
       viewBox="0 0 40 40"
       style={{ transform: `rotate(${rotation}deg)` }}
     >
@@ -124,7 +124,7 @@ export function WeatherSlide({
                   <img
                     src={weatherIconSrc(day.icon)}
                     alt={day.description}
-                    className="h-[80px] w-[80px] shrink-0"
+                    className="size-[80px] shrink-0"
                     onError={(e) => {
                       const img = e.currentTarget
                       const fallback = `/icons/weather/${day.icon.replace(/[dn]$/, '')}.svg`

--- a/src/components/zuidwest/Header.tsx
+++ b/src/components/zuidwest/Header.tsx
@@ -39,7 +39,7 @@ export function Header({ theme }: { theme: 'green' | 'blue' }) {
         style={{ backgroundColor: c.pillBg }}
       >
         <svg
-          className="mr-[10px] h-[36px] w-[36px]"
+          className="mr-[10px] size-[36px]"
           viewBox="0 0 40 40"
           fill="none"
           stroke={c.clockStroke}

--- a/src/components/zuidwest/WeatherSlide.tsx
+++ b/src/components/zuidwest/WeatherSlide.tsx
@@ -34,7 +34,7 @@ function WindArrow({ direction }: { direction: string }) {
 
   return (
     <svg
-      className="h-[68px] w-[68px] shrink-0"
+      className="size-[68px] shrink-0"
       viewBox="0 0 40 40"
       style={{ transform: `rotate(${rotation}deg)` }}
     >
@@ -140,7 +140,7 @@ export function WeatherSlide({
                   <img
                     src={weatherIconSrc(day.icon)}
                     alt={day.description}
-                    className="h-[72px] w-[72px]"
+                    className="size-[72px]"
                     onError={(e) => {
                       const img = e.currentTarget
                       const fallback = `/icons/weather/${day.icon.replace(/[dn]$/, '')}.svg`


### PR DESCRIPTION
## Summary
- Surfaced by [react-doctor](https://www.react.doctor) — the codebase scored **91/100 ("Great")** with 41 warnings, 0 errors.
- This PR addresses only one of the rules (`design-no-redundant-size-axes`): collapsing `w-[N] h-[N]` (matching axes) into Tailwind v3.4+ `size-[N]` shorthand.
- 5 trivial replacements across 3 files. No visual or runtime impact.

## Other react-doctor findings — intentionally not addressed here
Most of the remaining warnings are either domain-mismatch (this is a 1080p cable-TV playout renderer, not an interactive web app) or out of scope for a tidy-up PR:

| Rule | Count | Why skipped |
|---|---|---|
| `no-pure-black-background` | 3 | `bg-black` is correct for broadcast output |
| `design-no-bold-heading` | 4 | TV is read at distance — bold headings are intentional |
| `no-danger` (`dangerouslySetInnerHTML`) | 5 | Real concern but data is from a trusted CMS; needs a separate decision on sanitization (DOMPurify / allowlist) |
| `no-cascading-set-state` (useReducer) | 2 | Substantial refactor of `useCarousel.ts`, separate ticket |
| `no-document-start-view-transition` | 1 | Current API works; React 19 `<ViewTransition>` integration is bleeding edge |
| `js-batch-dom-css`, `js-combine-iterations`, `rendering-svg-precision` | 7 | Micro-optimizations with no measurable effect at playlist scale |
| `knip` dead code | 14 | Mostly false positives — `types.examples.ts` is intentionally non-imported (validated by `tsc --noEmit` only), so its imported symbols read as "unused" |

## Test plan
- [x] `bun run check` (astro check + tsc + bun test + biome ci) passes
- [ ] Visual check: weather slides (zuidwest + rucphen) and zuidwest header render unchanged