### PR TITLE
refactor: share weather primitives and ZuidWest slide shell

### DIFF
--- a/src/components/WeatherIcon.tsx
+++ b/src/components/WeatherIcon.tsx
@@ -1,0 +1,39 @@
+// Resolves an OWM icon code to a local SVG. If the day/night variant is
+// missing, falls back once to the generic icon; the dataset guard prevents an
+// endless error→retry loop when the fallback is missing too.
+export function WeatherIcon({
+  icon,
+  alt,
+  className,
+}: {
+  icon: string
+  alt: string
+  className?: string
+}) {
+  return (
+    <img
+      src={`/icons/weather/${icon}.svg`}
+      alt={alt}
+      className={className}
+      onError={(e) => {
+        const img = e.currentTarget
+        const fallback = `/icons/weather/${icon.replace(/[dn]$/, '')}.svg`
+        if (
+          img.dataset.fallbackApplied === 'true' ||
+          img.getAttribute('src') === fallback
+        ) {
+          console.error(
+            `Weather icon failed to load, including fallback: ${fallback}`,
+          )
+          img.dataset.fallbackApplied = 'true'
+          return
+        }
+        console.warn(
+          `Weather icon failed to load: ${img.getAttribute('src')}. Falling back to ${fallback}`,
+        )
+        img.dataset.fallbackApplied = 'true'
+        img.src = fallback
+      }}
+    />
+  )
+}

--- a/src/components/WindArrow.tsx
+++ b/src/components/WindArrow.tsx
@@ -1,0 +1,38 @@
+import { windRotation } from '../utils/windDirection'
+
+export function WindArrow({
+  direction,
+  stroke,
+  className,
+}: {
+  direction: string
+  stroke: string
+  className?: string
+}) {
+  const rotation = windRotation(direction)
+
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 40 40"
+      style={{ transform: `rotate(${rotation}deg)` }}
+    >
+      <circle
+        cx="20"
+        cy="20"
+        r="18"
+        fill="none"
+        stroke={stroke}
+        strokeWidth="2"
+      />
+      <path
+        d="M20 10 L20 30 M20 10 L13 17 M20 10 L27 17"
+        fill="none"
+        stroke={stroke}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/src/components/rucphen/WeatherSlide.tsx
+++ b/src/components/rucphen/WeatherSlide.tsx
@@ -1,41 +1,7 @@
 import type { WeatherSlideData } from '../../types'
 import { tempStyle } from '../../utils/tempColor'
-import { windRotation } from '../../utils/windDirection'
-
-function weatherIconSrc(icon: string): string {
-  const base = `/icons/weather/${icon}.svg`
-  const fallback = `/icons/weather/${icon.replace(/[dn]$/, '')}.svg`
-  return base !== fallback ? base : fallback
-}
-
-function WindArrow({ direction }: { direction: string }) {
-  const rotation = windRotation(direction)
-
-  return (
-    <svg
-      className="size-[48px] shrink-0"
-      viewBox="0 0 40 40"
-      style={{ transform: `rotate(${rotation}deg)` }}
-    >
-      <circle
-        cx="20"
-        cy="20"
-        r="18"
-        fill="none"
-        stroke="white"
-        strokeWidth="2"
-      />
-      <path
-        d="M20 10 L20 30 M20 10 L13 17 M20 10 L27 17"
-        fill="none"
-        stroke="white"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  )
-}
+import { WeatherIcon } from '../WeatherIcon'
+import { WindArrow } from '../WindArrow'
 
 export function WeatherSlide({
   content,
@@ -104,15 +70,10 @@ export function WeatherSlide({
 
                 {/* Weather icon + description */}
                 <div className="flex w-[380px] shrink-0 items-center gap-[16px]">
-                  <img
-                    src={weatherIconSrc(day.icon)}
+                  <WeatherIcon
+                    icon={day.icon}
                     alt={day.description}
                     className="size-[80px] shrink-0"
-                    onError={(e) => {
-                      const img = e.currentTarget
-                      const fallback = `/icons/weather/${day.icon.replace(/[dn]$/, '')}.svg`
-                      if (img.src !== fallback) img.src = fallback
-                    }}
                   />
                   <span className="text-[28px] text-shadow text-white leading-tight">
                     {day.description}
@@ -159,7 +120,11 @@ export function WeatherSlide({
                       strokeWidth="2"
                     />
                   </svg>
-                  <WindArrow direction={day.wind_direction} />
+                  <WindArrow
+                    direction={day.wind_direction}
+                    stroke="white"
+                    className="size-[48px] shrink-0"
+                  />
                   <div className="flex flex-col">
                     <span className="font-bold text-[28px] text-shadow text-white leading-none">
                       {day.wind_direction}

--- a/src/components/zuidwest/Background.tsx
+++ b/src/components/zuidwest/Background.tsx
@@ -1,25 +1,10 @@
-const themes = {
-  green: {
-    bg: '#e9e9e9',
-    topBand: '#82ba26',
-    topBandDark: '#003500',
-    triLarge: '#42ab33',
-    triSmall: '#008c3b',
-  },
-  blue: {
-    bg: '#e9e9e9',
-    topBand: '#009fe3',
-    topBandDark: '#000035',
-    triLarge: '#0064d7',
-    triSmall: '#0033cc',
-  },
-} as const
+import { type ThemeName, themes } from './theme'
 
 export function Background({
   theme,
   children,
 }: {
-  theme: 'green' | 'blue'
+  theme: ThemeName
   children: React.ReactNode
 }) {
   const c = themes[theme]
@@ -27,7 +12,7 @@ export function Background({
   return (
     <div
       className="relative h-full w-full overflow-hidden"
-      style={{ backgroundColor: c.bg }}
+      style={{ backgroundColor: c.surface }}
     >
       {/* Background layer (behind content) */}
       <svg
@@ -36,11 +21,11 @@ export function Background({
         preserveAspectRatio="none"
       >
         {/* Green band — top 600px, right 640px is dark */}
-        <rect x="0" y="0" width="1280" height="600" fill={c.topBand} />
-        <rect x="1280" y="0" width="640" height="600" fill={c.topBandDark} />
+        <rect x="0" y="0" width="1280" height="600" fill={c.accent} />
+        <rect x="1280" y="0" width="640" height="600" fill={c.accentDark} />
         {/* Top-left corner triangles */}
-        <polygon points="0,0 0,320 160,0" fill={c.triLarge} />
-        <polygon points="0,0 0,192 96,0" fill={c.triSmall} />
+        <polygon points="0,0 0,320 160,0" fill={c.accentMid} />
+        <polygon points="0,0 0,192 96,0" fill={c.accentDeep} />
       </svg>
 
       {/* Content layer (no z-index — children use parent stacking context) */}
@@ -55,23 +40,20 @@ export function Background({
         {/* Right-side diagonal stripes (over the card/photo) */}
         <path
           d="M 1920,600 H 1784 V 968 C 1806,968 1832,952 1842,932 L 1920,776 Z"
-          fill={c.topBand}
+          fill={c.accent}
         />
         <polygon
           points="1920,472 1784,744 1784,896 1920,624"
-          fill={c.triLarge}
+          fill={c.accentMid}
         />
         <path
           d="M 1920,373 C 1897,391 1878,412 1866,435 L 1784,600 V 744 L 1920,472 Z"
-          fill={c.triSmall}
+          fill={c.accentDeep}
         />
         {/* Top-right logo bar stripes */}
-        <polygon points="1160,0 1080,160 1160,160 1240,0" fill={c.triLarge} />
-        <polygon points="1240,0 1160,160 1280,160 1360,0" fill={c.triSmall} />
-        <polygon
-          points="1360,0 1280,160 1920,160 1920,0"
-          fill={c.topBandDark}
-        />
+        <polygon points="1160,0 1080,160 1160,160 1240,0" fill={c.accentMid} />
+        <polygon points="1240,0 1160,160 1280,160 1360,0" fill={c.accentDeep} />
+        <polygon points="1360,0 1280,160 1920,160 1920,0" fill={c.accentDark} />
       </svg>
     </div>
   )

--- a/src/components/zuidwest/Frame.tsx
+++ b/src/components/zuidwest/Frame.tsx
@@ -1,11 +1,12 @@
 import { Background } from './Background'
 import { Header } from './Header'
+import type { ThemeName } from './theme'
 
 export function Frame({
   theme,
   children,
 }: {
-  theme: 'green' | 'blue'
+  theme: ThemeName
   children: React.ReactNode
 }) {
   return (

--- a/src/components/zuidwest/Header.tsx
+++ b/src/components/zuidwest/Header.tsx
@@ -1,27 +1,18 @@
 import { Clock } from '../Clock'
+import { type ThemeName, themes } from './theme'
 
-const themes = {
-  green: {
-    pillBg: '#003500',
-    clockStroke: '#42ab33',
-  },
-  blue: {
-    pillBg: '#000035',
-    clockStroke: '#0064d7',
-  },
-} as const
+const dateFormatter = new Intl.DateTimeFormat('nl-NL', {
+  weekday: 'long',
+  day: 'numeric',
+  month: 'long',
+})
 
 function DateDisplay() {
-  const now = new Date()
-  const formatted = now.toLocaleDateString('nl-NL', {
-    weekday: 'long',
-    day: 'numeric',
-    month: 'long',
-  })
+  const formatted = dateFormatter.format(new Date())
   return <span>{formatted.charAt(0).toUpperCase() + formatted.slice(1)}</span>
 }
 
-export function Header({ theme }: { theme: 'green' | 'blue' }) {
+export function Header({ theme }: { theme: ThemeName }) {
   const c = themes[theme]
 
   return (
@@ -36,13 +27,13 @@ export function Header({ theme }: { theme: 'green' | 'blue' }) {
       {/* Time pill (dark filled) with clock icon */}
       <div
         className="absolute top-[72px] left-[192px] flex h-[56px] items-center rounded-full pr-[28px] pl-[10px]"
-        style={{ backgroundColor: c.pillBg }}
+        style={{ backgroundColor: c.accentDark }}
       >
         <svg
           className="mr-[10px] size-[36px]"
           viewBox="0 0 40 40"
           fill="none"
-          stroke={c.clockStroke}
+          stroke={c.accentMid}
           strokeWidth="4"
           strokeLinecap="round"
           strokeLinejoin="round"

--- a/src/components/zuidwest/SlideShell.tsx
+++ b/src/components/zuidwest/SlideShell.tsx
@@ -1,0 +1,29 @@
+import { type ThemeName, themes } from './theme'
+
+// Accent container, card surface, and ticker slot shared by the card-style
+// slides (TextSlide, WeatherSlide); children render inside the card. Card
+// geometry changes happen here once.
+export function SlideShell({
+  theme,
+  ticker,
+  children,
+}: {
+  theme: ThemeName
+  ticker?: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      className="absolute top-[160px] bottom-[112px] left-[134px] flex flex-col gap-[2px] rounded-tl-[42px] rounded-tr-[80px] rounded-bl-[42px] pb-[2px]"
+      style={{ backgroundColor: themes[theme].accent, width: '1650px' }}
+    >
+      <div
+        className="relative ml-[2px] flex flex-1 flex-col overflow-hidden rounded-tl-[40px] rounded-tr-[40px] font-nunito"
+        style={{ backgroundColor: themes[theme].surface }}
+      >
+        {children}
+      </div>
+      {ticker && <div className="ml-[2px]">{ticker}</div>}
+    </div>
+  )
+}

--- a/src/components/zuidwest/TextSlide.tsx
+++ b/src/components/zuidwest/TextSlide.tsx
@@ -1,61 +1,43 @@
 import type { TextSlideData } from '../../types'
-
-const themes = {
-  green: { border: '#82ba26' },
-  blue: { border: '#009fe3' },
-} as const
+import { SlideShell } from './SlideShell'
+import type { ThemeName } from './theme'
 
 export function TextSlide({
   content,
-  theme = 'green',
+  theme,
   children,
 }: {
   content: TextSlideData
-  theme?: 'green' | 'blue'
+  theme: ThemeName
   children?: React.ReactNode
 }) {
-  const c = themes[theme]
   const imageUrl = content.image?.url
   const hasImage = !!imageUrl
 
   return (
     <>
-      {/* Green accent flex container — height determined by top/bottom */}
-      <div
-        className="absolute top-[160px] bottom-[112px] left-[134px] flex flex-col gap-[2px] rounded-tl-[42px] rounded-tr-[80px] rounded-bl-[42px] pb-[2px]"
-        style={{ backgroundColor: c.border, width: '1650px' }}
-      >
-        {/* Card (fills remaining space) */}
-        <div
-          className={
-            'ml-[2px] flex-1 overflow-hidden rounded-tl-[40px] rounded-tr-[40px] bg-[#e9e9e9] font-nunito'
-          }
-        >
-          <div className="h-full overflow-hidden px-[56px] pt-[32px]">
-            {/* Float spacer for photo area */}
-            {hasImage && (
-              <div
-                className="float-right ml-[20px]"
-                style={{ width: '448px', height: '408px' }}
-              />
-            )}
-
-            {/* Title (renders HTML entities) */}
-            <h1
-              className="mb-[44px] font-black text-[#1d1d1b] text-[58px] leading-[59px]"
-              dangerouslySetInnerHTML={{ __html: content.title }}
+      <SlideShell theme={theme} ticker={children}>
+        <div className="h-full overflow-hidden px-[56px] pt-[32px]">
+          {/* Float spacer for photo area */}
+          {hasImage && (
+            <div
+              className="float-right ml-[20px]"
+              style={{ width: '448px', height: '408px' }}
             />
+          )}
 
-            {/* Body */}
-            <div className="font-[500] text-[#1d1d1b] text-[42px] leading-[58px]">
-              <div dangerouslySetInnerHTML={{ __html: content.body }} />
-            </div>
+          {/* Title (renders HTML entities) */}
+          <h1
+            className="mb-[44px] font-black text-[#1d1d1b] text-[58px] leading-[59px]"
+            dangerouslySetInnerHTML={{ __html: content.title }}
+          />
+
+          {/* Body */}
+          <div className="font-[500] text-[#1d1d1b] text-[42px] leading-[58px]">
+            <div dangerouslySetInnerHTML={{ __html: content.body }} />
           </div>
         </div>
-
-        {/* Ticker slot (passed as children) */}
-        {children && <div className="ml-[2px]">{children}</div>}
-      </div>
+      </SlideShell>
 
       {/* Photo (outside card so it extends behind overlay stripes) */}
       {hasImage && (

--- a/src/components/zuidwest/Ticker.tsx
+++ b/src/components/zuidwest/Ticker.tsx
@@ -1,9 +1,5 @@
 import type { TickerItem } from '../../types'
-
-const themes = {
-  green: { arrow: '#82ba26', tickerBg: '#e0eec9' },
-  blue: { arrow: '#009fe3', tickerBg: '#bfe7f8' },
-} as const
+import { type ThemeName, themes } from './theme'
 
 function parseTicker(message: string) {
   const colonIndex = message.indexOf(': ')
@@ -19,11 +15,11 @@ function parseTicker(message: string) {
 export function Ticker({
   items,
   currentIndex,
-  theme = 'green',
+  theme,
 }: {
   items: TickerItem[]
   currentIndex: number
-  theme?: 'green' | 'blue'
+  theme: ThemeName
 }) {
   if (items.length === 0) return null
 
@@ -48,7 +44,7 @@ export function Ticker({
             className="mx-[21px] h-[36px] w-[42px]"
             viewBox="-3 -3 42 36"
             fill="none"
-            stroke={c.arrow}
+            stroke={c.accent}
             strokeWidth="4"
             strokeLinecap="round"
             strokeLinejoin="miter"

--- a/src/components/zuidwest/WeatherSlide.tsx
+++ b/src/components/zuidwest/WeatherSlide.tsx
@@ -1,56 +1,19 @@
 import type { WeatherSlideData } from '../../types'
 import { tempStyle } from '../../utils/tempColor'
-import { windRotation } from '../../utils/windDirection'
-
-const themes = {
-  green: { border: '#82ba26' },
-  blue: { border: '#009fe3' },
-} as const
-
-// Resolve OWM icon code to local SVG path. Fallback is handled in onError.
-function weatherIconSrc(icon: string): string {
-  return `/icons/weather/${icon}.svg`
-}
-
-function WindArrow({ direction }: { direction: string }) {
-  const rotation = windRotation(direction)
-
-  return (
-    <svg
-      className="size-[68px] shrink-0"
-      viewBox="0 0 40 40"
-      style={{ transform: `rotate(${rotation}deg)` }}
-    >
-      <circle
-        cx="20"
-        cy="20"
-        r="18"
-        fill="none"
-        stroke="#000"
-        strokeWidth="2"
-      />
-      <path
-        d="M20 10 L20 30 M20 10 L13 17 M20 10 L27 17"
-        fill="none"
-        stroke="#000"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  )
-}
+import { WeatherIcon } from '../WeatherIcon'
+import { WindArrow } from '../WindArrow'
+import { SlideShell } from './SlideShell'
+import type { ThemeName } from './theme'
 
 export function WeatherSlide({
   content,
-  theme = 'green',
+  theme,
   children,
 }: {
   content: WeatherSlideData
-  theme?: 'green' | 'blue'
+  theme: ThemeName
   children?: React.ReactNode
 }) {
-  const c = themes[theme]
   const days = content.days.slice(0, 5)
   if (days.length === 0) return null
 
@@ -68,151 +31,120 @@ export function WeatherSlide({
   const colMin = 'w-[136px]'
 
   return (
-    <>
-      {/* Green accent flex container */}
-      <div
-        className="absolute top-[160px] bottom-[112px] left-[134px] flex flex-col gap-[2px] rounded-tl-[42px] rounded-tr-[80px] rounded-bl-[42px] pb-[2px]"
-        style={{ backgroundColor: c.border, width: '1650px' }}
-      >
-        {/* Card */}
-        <div className="relative ml-[2px] flex flex-1 flex-col overflow-hidden rounded-tl-[40px] rounded-tr-[40px] bg-[#e9e9e9] font-nunito">
-          {/* Weerstation pill */}
-          <div className="absolute top-[20px] right-[56px] flex items-center rounded-full border-2 border-white px-[31px] py-[18px]">
-            <img
-              src="/icons/weather/weerstation.svg"
-              alt=""
-              className="mr-[22px] w-[40px]"
-              style={{ transform: 'scale(1.8) translate(3px, -1px)' }}
-            />
-            <span className="font-[600] text-[#1d1d1b] text-[32px] leading-none">
-              Weerstation {content.location}
+    <SlideShell theme={theme} ticker={children}>
+      {/* Weerstation pill */}
+      <div className="absolute top-[20px] right-[56px] flex items-center rounded-full border-2 border-white px-[31px] py-[18px]">
+        <img
+          src="/icons/weather/weerstation.svg"
+          alt=""
+          className="mr-[22px] w-[40px]"
+          style={{ transform: 'scale(1.8) translate(3px, -1px)' }}
+        />
+        <span className="font-[600] text-[#1d1d1b] text-[32px] leading-none">
+          Weerstation {content.location}
+        </span>
+      </div>
+
+      {/* Header row */}
+      <div className="px-[56px] pt-[36px] pb-[20px]">
+        <h1 className="font-black text-[#1d1d1b] text-[58px] leading-[59px]">
+          Weer
+        </h1>
+      </div>
+
+      {/* Weather table */}
+      <div className="mx-[56px] mt-[4px] mb-[40px] flex flex-1 flex-col overflow-hidden">
+        {days.map((day, i) => (
+          <div
+            key={day.date}
+            className="box-content flex h-[94px] items-stretch text-[36px]"
+            style={{
+              borderTop: i === 0 ? '2px solid white' : 'none',
+              borderBottom: '2px solid white',
+            }}
+          >
+            {/* Day name */}
+            <div
+              className={`${colDay} flex items-center font-bold text-[#1d1d1b] text-[42px]`}
+            >
+              {day.day_short === 'vandaag'
+                ? day.day_short
+                : day.date.split(' ')[0]}
+            </div>
+
+            {/* Weather icon */}
+            <div
+              className={`${colIcon} mr-[40px] flex items-center justify-center`}
+            >
+              <WeatherIcon
+                icon={day.icon}
+                alt={day.description}
+                className="size-[72px]"
+              />
+            </div>
+
+            {/* Max temp (green column) */}
+            <div
+              className={`${colMax} flex items-center justify-center font-[800] text-[44px]`}
+              style={tempStyle(day.temp_max)}
+            >
+              {day.temp_max}°
+            </div>
+
+            {/* Min temp (light green column) */}
+            <div
+              className={`${colMin} flex items-center justify-center text-[44px]`}
+              style={tempStyle(day.temp_min)}
+            >
+              {day.temp_min}°
+            </div>
+
+            {/* Wind (blue column) */}
+            <div className="flex flex-1 items-center gap-[18px] pl-[35px]">
+              <WindArrow
+                direction={day.wind_direction}
+                stroke="#000"
+                className="size-[68px] shrink-0"
+              />
+              <span className="font-[600] text-[#1d1d1b] text-[32px] leading-none">
+                {day.wind_direction}
+                <br />
+                {day.wind_beaufort}-{day.wind_beaufort + 1} Bft
+              </span>
+            </div>
+          </div>
+        ))}
+
+        {/* Klimaatgemiddelde row */}
+        <div className="flex flex-1 items-stretch">
+          {/* Left: label + max avg — colored by high temp */}
+          <div
+            className="flex items-center"
+            style={{
+              ...tempStyle(avgMax),
+              width: `calc(264px + 120px + 40px + 136px)`,
+            }}
+          >
+            <span className="pl-[24px] font-[600] text-[35px]">
+              klimaatgemiddelde
             </span>
+            <div
+              className={`${colMax} ml-auto flex items-center justify-center font-[800] text-[44px]`}
+            >
+              {avgMax}°
+            </div>
           </div>
 
-          {/* Header row */}
-          <div className="px-[56px] pt-[36px] pb-[20px]">
-            <h1 className="font-black text-[#1d1d1b] text-[58px] leading-[59px]">
-              Weer
-            </h1>
-          </div>
-
-          {/* Weather table */}
-          <div className="mx-[56px] mt-[4px] mb-[40px] flex flex-1 flex-col overflow-hidden">
-            {days.map((day, i) => (
-              <div
-                key={day.date}
-                className="box-content flex h-[94px] items-stretch text-[36px]"
-                style={{
-                  borderTop: i === 0 ? '2px solid white' : 'none',
-                  borderBottom: '2px solid white',
-                }}
-              >
-                {/* Day name */}
-                <div
-                  className={`${colDay} flex items-center font-bold text-[#1d1d1b] text-[42px]`}
-                >
-                  {day.day_short === 'vandaag'
-                    ? day.day_short
-                    : day.date.split(' ')[0]}
-                </div>
-
-                {/* Weather icon */}
-                <div
-                  className={`${colIcon} mr-[40px] flex items-center justify-center`}
-                >
-                  <img
-                    src={weatherIconSrc(day.icon)}
-                    alt={day.description}
-                    className="size-[72px]"
-                    onError={(e) => {
-                      const img = e.currentTarget
-                      const fallback = `/icons/weather/${day.icon.replace(/[dn]$/, '')}.svg`
-                      const currentSrc = img.getAttribute('src')
-                      if (
-                        img.dataset.fallbackApplied === 'true' ||
-                        currentSrc === fallback
-                      ) {
-                        console.error(
-                          `Weather icon failed to load, including fallback: ${fallback}`,
-                        )
-                        img.dataset.fallbackApplied = 'true'
-                        return
-                      }
-                      console.warn(
-                        `Weather icon failed to load: ${currentSrc}. Falling back to ${fallback}`,
-                      )
-                      img.dataset.fallbackApplied = 'true'
-                      img.src = fallback
-                    }}
-                  />
-                </div>
-
-                {/* Max temp (green column) */}
-                <div
-                  className={`${colMax} flex items-center justify-center font-[800] text-[44px]`}
-                  style={tempStyle(day.temp_max)}
-                >
-                  {day.temp_max}°
-                </div>
-
-                {/* Min temp (light green column) */}
-                <div
-                  className={`${colMin} flex items-center justify-center text-[44px]`}
-                  style={tempStyle(day.temp_min)}
-                >
-                  {day.temp_min}°
-                </div>
-
-                {/* Wind (blue column) */}
-                <div className="flex flex-1 items-center gap-[18px] pl-[35px]">
-                  <WindArrow direction={day.wind_direction} />
-                  <span className="font-[600] text-[#1d1d1b] text-[32px] leading-none">
-                    {day.wind_direction}
-                    <br />
-                    {day.wind_beaufort}-{day.wind_beaufort + 1} Bft
-                  </span>
-                </div>
-              </div>
-            ))}
-
-            {/* Klimaatgemiddelde row */}
-            <div className="flex flex-1 items-stretch">
-              {/* Left: label + max avg — colored by high temp */}
-              <div
-                className="flex items-center"
-                style={{
-                  ...tempStyle(avgMax),
-                  width: `calc(264px + 120px + 40px + 136px)`,
-                }}
-              >
-                <span className="pl-[24px] font-[600] text-[35px]">
-                  klimaatgemiddelde
-                </span>
-                <div
-                  className={`${colMax} ml-auto flex items-center justify-center font-[800] text-[44px]`}
-                >
-                  {avgMax}°
-                </div>
-              </div>
-
-              {/* Right: min avg + rest — colored by low temp */}
-              <div
-                className="flex flex-1 items-center"
-                style={tempStyle(avgMin)}
-              >
-                <div
-                  className={`${colMin} flex items-center justify-center text-[44px]`}
-                >
-                  {avgMin}°
-                </div>
-              </div>
+          {/* Right: min avg + rest — colored by low temp */}
+          <div className="flex flex-1 items-center" style={tempStyle(avgMin)}>
+            <div
+              className={`${colMin} flex items-center justify-center text-[44px]`}
+            >
+              {avgMin}°
             </div>
           </div>
         </div>
-
-        {/* Ticker slot */}
-        {children && <div className="ml-[2px]">{children}</div>}
       </div>
-    </>
+    </SlideShell>
   )
 }


### PR DESCRIPTION
## Summary

- share WeatherIcon and WindArrow between both brands
- prevent repeated weather-icon fallback retries
- centralize the ZuidWest palette
- share the card and ticker shell between ZuidWest text and weather slides

This is stack 2/4 replacing #161 and depends on #167. GitHub shows only this PR's focused diff against its stack base.

## Test plan

- `bun run check`
- 41 tests pass
- visually compare both weather designs before merge